### PR TITLE
add html to output instead of md

### DIFF
--- a/Literate.md
+++ b/Literate.md
@@ -1411,7 +1411,7 @@ Finally we add this html to the output and add a newline for good measure.
 
 ### Weave a prose block +=
 ```d
-output ~= md ~ "\n";
+output ~= html ~ "\n";
 ```
 
 ## Weave a code block


### PR DESCRIPTION
After md was converted to html, the original md was added to the output, instead of the converted html.
